### PR TITLE
Add multiarch build/push for edge images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+DOCKER_REGISTRY?=quay.io
+DOCKER_PROJECT?=jdzon
+DOCKER_TAG?=v1
+
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# This is a requirement for 'setup-envtest.sh' in the test target.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+
+
+.PHONY: build-dependencies
+build-dependencies:
+	sudo dnf install podman buildah qemu-user-static -y
+
+build-%: build-dependencies
+	buildah build --jobs=2 --platform=linux/amd64,linux/arm64 --manifest ${DOCKER_REGISTRY}/$(DOCKER_PROJECT)/$*:$(DOCKER_TAG) poc-demo/edge/$*
+
+.PHONY: build-edge
+build-edge: build-random-server build-os-stats
+
+push-%:	build-%*
+	podman manifest push --all $(DOCKER_REGISTRY)/$(DOCKER_PROJECT)/$*:$(DOCKER_TAG) docker://$(DOCKER_REGISTRY)/$(DOCKER_PROJECT)/random$*:$(DOCKER_TAG)
+
+.PHONY: push-edge
+push-edge: push-random-server push-os-stats

--- a/poc-demo/edge/os-stats/Dockerfile
+++ b/poc-demo/edge/os-stats/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.9-slim-buster
 RUN mkdir /code
 WORKDIR /code
 
-RUN python3.9 -m pip install psutil
+RUN apt-get update && apt-get install -y python3-pip && pip3 install psutil
 
 COPY stats.py .
 
-CMD ["python3.9", "stats.py"]
+CMD ["python3", "stats.py"]

--- a/poc-demo/edge/os-stats/stats.py
+++ b/poc-demo/edge/os-stats/stats.py
@@ -6,8 +6,7 @@ import psutil
 
 stats_dir = "/export/stats"
 
-if not os.path.exists(stats_dir):
-    os.mkdir(stats_dir)
+os.makedirs(stats_dir)
 
 while True:
     file_name = datetime.today().strftime('%Y-%m-%d_%H-%M-%S')

--- a/poc-demo/edge/random-server/Dockerfile
+++ b/poc-demo/edge/random-server/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.9-slim-buster
 RUN mkdir /code
 WORKDIR /code
 
-RUN python3.9 -m pip install psutil cpu-load-generator
+RUN apt-get update && apt-get install -y python3-pip && pip3 install psutil cpu-load-generator
+
 COPY random-server.py .
 
-CMD ["python3.9", "random-server.py"]
+CMD ["python3", "random-server.py"]


### PR DESCRIPTION
Creates a multiarch image for linux/amd64 and linux/arm64 for the edge examples using buildah and podman. The PR also contains a Makefile for convenience that will install the binary dependencies (qemu-user-static, buildah and podman), build and push the images to the target registry (configurable via env variables).

Due to constrains in the python's arm64 packages, I had to amend the Dockerfiles to use `apt-get` first to get the packaged pip (python 3.7) and then install the required packages, instead of using the existing `pip` (python 3.9) to install the python eggs. Turns out that the arm64 version of `psutil` that installs with pip (python 3.9) requires recompilation (gcc), but using the pip from python 3.7 does not.

The default tag generated uses the following format: v<date>-<git commit hash>

@jakub-dzon can you review please?

Signed-off-by: Jordi Gil <jgil@redhat.com>